### PR TITLE
bug fix for load SNLDA from Recursive LDA

### DIFF
--- a/src/sampler/unsupervised/RecursiveLDA.java
+++ b/src/sampler/unsupervised/RecursiveLDA.java
@@ -74,8 +74,8 @@ public class RecursiveLDA extends AbstractSampler {
 
     public DirMult getTopicWord(int[] path) {
         RLDA node = rootLDA;
-        for (int ll = 1; ll < path.length - 1; ll++) {
-            node = node.getChild(path[ll]);
+        for (int ll = 1; ll < path.length ; ll++) {
+            node = node.getChild(path[ll-1]);
         }
         return node.getTopicWords()[path[path.length - 1]];
     }


### PR DESCRIPTION
Bug wouldn't allow you to run SNLDA with Ks=10,20, or any other values where 3rd layer is bigger than 2nd layer. Problem occurs when loading model from recursive LDA.